### PR TITLE
Add support for rgb[a] and hsl[a] colors

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   color
 author Christopher Smith
 email  chris@jalakai.co.uk
-date   2018-08-09
+date   2018-09-19
 name   color syntax plugin
 desc   Write colored text in DokuWiki.
 url    https://www.dokuwiki.org/plugin:color

--- a/syntax.php
+++ b/syntax.php
@@ -94,15 +94,18 @@ class syntax_plugin_color extends DokuWiki_Syntax_Plugin {
     }
  
     // validate color value $c
-    // this is cut price validation - only to ensure the basic format is correct and there is nothing harmful
-    // three basic formats  "colorname", "#fff[fff]", "rgb(255[%],255[%],255[%])"
+    // this is cut price validation - only to ensure there is nothing harmful
+    // recognize rgb, rgba, hsl, hsla but don't try to valiedate their arguments,
+    // just ensure that no illegal characters are included therein
+    // and that the number of characters is reasonable
+    // leave it to the browsers to ignore a faulty colour specification
     function _isValid($c) {
         $c = trim($c);
  
         $pattern = "/^\s*(
-            ([a-zA-Z]+)|                                #colorname - not verified
-            (\#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}))|        #colorvalue
-            (rgb\(([0-9]{1,3}%?,){2}[0-9]{1,3}%?\))     #rgb triplet
+            ([a-zA-Z]+)|                         #colorname - not verified
+            (\#([0-9a-fA-F]{3,8}))|              #colorvalue including possible alpha
+            ((rgba?|hsla?)\([0-9%., ]{5,40}\))   #rgb[a], hsl[a]
             )\s*$/x";
  
         if (preg_match($pattern, $c)) return trim($c);


### PR DESCRIPTION
Here is a proposed change to the color plugin, in order to support hsl, hsla, and rgba color specifications. Rather than trying to write a regexp to cover all possible formats, I found it more reasonable to write one that merely tries to ensure that nothing “harmful” slips through. If the user writes an invalid specification, the worst thing to happen is that the browser ignores it.

Note that starting with level 4 css, rgb and hsl can take either three or four arguments. With four arguments, they act just like rgba and hsla. (Likewise, I think rgba and hsla can be given just three arguments, thus acting like rgb and hsl.) I say, let's leave  the detailed checking to the browser!